### PR TITLE
Update to fix text related NRE in new game version

### DIFF
--- a/PlanBuild/Blueprints/BlueprintAssets.cs
+++ b/PlanBuild/Blueprints/BlueprintAssets.cs
@@ -6,6 +6,7 @@ using PlanBuild.Utils;
 using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.UI;
+using TMPro;
 using Object = UnityEngine.Object;
 
 namespace PlanBuild.Blueprints
@@ -74,8 +75,8 @@ namespace PlanBuild.Blueprints
             BlueprintTooltip = prefabs[BlueprintTooltipName];
             void InitTooltipGUI()
             {
-                global::Utils.FindChild(BlueprintTooltip.transform, "BPText").GetComponent<Text>().font =
-                    GUIManager.Instance.AveriaSerif;
+
+                global::Utils.FindChild(BlueprintTooltip.transform, "BPText").GetComponent<TMP_Text>().font = TMP_FontAsset.CreateFontAsset(GUIManager.Instance.AveriaSerif);
                 GUIManager.OnCustomGUIAvailable -= InitTooltipGUI;
             }
             GUIManager.OnCustomGUIAvailable += InitTooltipGUI;

--- a/PlanBuild/Blueprints/BlueprintAssets.cs
+++ b/PlanBuild/Blueprints/BlueprintAssets.cs
@@ -76,7 +76,7 @@ namespace PlanBuild.Blueprints
             void InitTooltipGUI()
             {
 
-                global::Utils.FindChild(BlueprintTooltip.transform, "BPText").GetComponent<TMP_Text>().font = TMP_FontAsset.CreateFontAsset(GUIManager.Instance.AveriaSerif);
+                global::Utils.FindChild(BlueprintTooltip.transform, "BPText").GetComponent<Text>().font = GUIManager.Instance.AveriaSerif;
                 GUIManager.OnCustomGUIAvailable -= InitTooltipGUI;
             }
             GUIManager.OnCustomGUIAvailable += InitTooltipGUI;

--- a/PlanBuild/Blueprints/BlueprintGUI.cs
+++ b/PlanBuild/Blueprints/BlueprintGUI.cs
@@ -117,14 +117,17 @@ namespace PlanBuild.Blueprints
                 {
                     UnityEngine.Object.DestroyImmediate(cat);
                 }
+
                 foreach (var detail in Instance.LocalTab.ListDisplay.Blueprints)
                 {
                     UnityEngine.Object.DestroyImmediate(detail.ContentHolder);
                 }
+
                 Instance.LocalTab.ListDisplay.Categories.Clear();
                 Instance.LocalTab.ListDisplay.Blueprints.Clear();
                 Instance.LocalTab.DetailDisplay.Clear();
             }
+
             if (location == BlueprintLocation.Temporary || location == BlueprintLocation.All)
             {
                 foreach (var cat in Instance.ClipboardTab.ListDisplay.Categories)
@@ -139,6 +142,7 @@ namespace PlanBuild.Blueprints
                 Instance.ClipboardTab.ListDisplay.Blueprints.Clear();
                 Instance.ClipboardTab.DetailDisplay.Clear();
             }
+
             if (location == BlueprintLocation.Server || location == BlueprintLocation.All)
             {
                 foreach (var cat in Instance.ServerTab.ListDisplay.Categories)
@@ -165,7 +169,6 @@ namespace PlanBuild.Blueprints
             {
                 return;
             }
-
             ClearBlueprints(location);
 
             if (location == BlueprintLocation.Local || location == BlueprintLocation.All)
@@ -463,10 +466,9 @@ namespace PlanBuild.Blueprints
                 panel.sprite = GUIManager.Instance.GetSprite("woodpanel_settings");
                 panel.type = Image.Type.Sliced;
                 panel.material = PrefabManager.Cache.GetPrefab<Material>("litpanel");
-
-                foreach (TMP_Text txt in Window.GetComponentsInChildren<TMP_Text>(true))
+                foreach (Text txt in Window.GetComponentsInChildren<Text>(true))
                 {
-                    txt.font = TMP_FontAsset.CreateFontAsset(GUIManager.Instance.AveriaSerif);
+                    txt.font = GUIManager.Instance.AveriaSerif;
                 }
 
                 foreach (InputField fld in Window.GetComponentsInChildren<InputField>(true))
@@ -483,7 +485,7 @@ namespace PlanBuild.Blueprints
                     GUIManager.Instance.ApplyButtonStyle(btn);
                     if (btn.name.Equals("CreateThumbnail", StringComparison.Ordinal))
                     {
-                        btn.GetComponentInChildren<TMP_Text>(true).fontSize = 13;
+                        btn.GetComponentInChildren<Text>(true).fontSize = 13;
                     }
                 }
 
@@ -731,11 +733,11 @@ namespace PlanBuild.Blueprints
 
         public BlueprintDetailContent SelectedBlueprintDetail { get; set; }
 
-        public TMP_Text ID { get; set; }
-        public TMP_Text Creator { get; set; }
-        public TMP_Text Count { get; set; }
-        public TMP_Text SnapPoints { get; set; }
-        public TMP_Text TerrainMods { get; set; }
+        public Text ID { get; set; }
+        public Text Creator { get; set; }
+        public Text Count { get; set; }
+        public Text SnapPoints { get; set; }
+        public Text TerrainMods { get; set; }
         public Image Icon { get; set; }
         public InputField Name { get; set; }
         public InputField Category { get; set; }
@@ -895,11 +897,11 @@ namespace PlanBuild.Blueprints
                 ConfirmationOverlay.Register(overlayParent);
 
                 Transform detail = contentTransform.Find("Detail");
-                ID = detail.Find("ID").GetComponent<TMP_Text>();
-                Creator = detail.Find("Creator").GetComponent<TMP_Text>();
-                Count = detail.Find("Count").GetComponent<TMP_Text>();
-                SnapPoints = detail.Find("SnapPoints").GetComponent<TMP_Text>();
-                TerrainMods = detail.Find("TerrainMods").GetComponent<TMP_Text>();
+                ID = detail.Find("ID").GetComponent<Text>();
+                Creator = detail.Find("Creator").GetComponent<Text>();
+                Count = detail.Find("Count").GetComponent<Text>();
+                SnapPoints = detail.Find("SnapPoints").GetComponent<Text>();
+                TerrainMods = detail.Find("TerrainMods").GetComponent<Text>();
                 Icon = detail.Find("Thumbnail").GetComponent<Image>();
                 Icon.gameObject.SetActive(false);
                 Name = detail.Find("Name").GetComponent<InputField>();

--- a/PlanBuild/Blueprints/BlueprintGUI.cs
+++ b/PlanBuild/Blueprints/BlueprintGUI.cs
@@ -597,7 +597,7 @@ namespace PlanBuild.Blueprints
     {
         public Transform TabTransform { get; set; }
         public Button TabButton { get; set; }
-        public TMP_Text TabText { get; set; }
+        public Text TabText { get; set; }
         public GameObject TabContent { get; set; }
 
         public void Register(Transform window, string tabName, string tabText)
@@ -609,7 +609,7 @@ namespace PlanBuild.Blueprints
                 button.name = tabName;
                 TabTransform = button.transform;
                 TabButton = button.GetComponent<Button>();
-                TabText = button.transform.Find("Text").GetComponent<TMP_Text>();
+                TabText = button.transform.Find("Text").GetComponent<Text>();
                 TabContent = UnityEngine.Object.Instantiate(window.Find("TabContent").gameObject, window.Find("Content"));
                 TabContent.name = tabName;
             }
@@ -644,7 +644,7 @@ namespace PlanBuild.Blueprints
             {
                 GameObject cat = UnityEngine.Object.Instantiate(BlueprintCategoryPrefab, ScrollContentParent);
                 cat.SetActive(true);
-                cat.GetComponent<TMP_Text>().text = name;
+                cat.GetComponent<Text>().text = name;
                 Categories.Add(cat);
             }
             catch (Exception ex)
@@ -667,7 +667,7 @@ namespace PlanBuild.Blueprints
                 newBp.ContentHolder = UnityEngine.Object.Instantiate(BlueprintEntryPrefab, ScrollContentParent);
                 newBp.ContentHolder.SetActive(true);
                 newBp.Button = newBp.ContentHolder.GetComponent<Button>();
-                newBp.Text = newBp.ContentHolder.transform.Find("Text").GetComponent<TMP_Text>();
+                newBp.Text = newBp.ContentHolder.transform.Find("Text").GetComponent<Text>();
 
                 newBp.ID = bp.ID;
                 newBp.Name = bp.Name;
@@ -920,7 +920,7 @@ namespace PlanBuild.Blueprints
                 // Type dependend actions
                 if (tabType == BlueprintLocation.Local)
                 {
-                    TransferButton.GetComponentInChildren<TMP_Text>().text = "$gui_bpmarket_upload";
+                    TransferButton.GetComponentInChildren<Text>().text = "$gui_bpmarket_upload";
                 }
                 if (tabType == BlueprintLocation.Temporary)
                 {
@@ -929,7 +929,7 @@ namespace PlanBuild.Blueprints
                 }
                 if (tabType == BlueprintLocation.Server)
                 {
-                    TransferButton.GetComponentInChildren<TMP_Text>().text = "$gui_bpmarket_download";
+                    TransferButton.GetComponentInChildren<Text>().text = "$gui_bpmarket_download";
                 }
 
                 // Add valheim refresh icon
@@ -962,7 +962,7 @@ namespace PlanBuild.Blueprints
         public string SnapPoints { get; set; }
         public string TerrainMods { get; set; }
         public string Description { get; set; }
-        public TMP_Text Text { get; set; }
+        public Text Text { get; set; }
         public Sprite Icon { get; set; }
         public Button Button { get; set; }
         public int AdditionalRotation { get; set; }
@@ -971,7 +971,7 @@ namespace PlanBuild.Blueprints
     internal class UIConfirmationOverlay
     {
         public Transform ContentHolder { get; set; }
-        public TMP_Text ConfirmationDisplayText { get; set; }
+        public Text ConfirmationDisplayText { get; set; }
         public Button CancelButton { get; set; }
         public Button ConfirmButton { get; set; }
 
@@ -1000,7 +1000,7 @@ namespace PlanBuild.Blueprints
         public void Register(Transform overlayTransform)
         {
             ContentHolder = overlayTransform;
-            ConfirmationDisplayText = overlayTransform.Find("ConfirmText").GetComponent<TMP_Text>();
+            ConfirmationDisplayText = overlayTransform.Find("ConfirmText").GetComponent<Text>();
             ConfirmButton = overlayTransform.Find("ConfirmationButton").GetComponent<Button>();
             CancelButton = overlayTransform.Find("CancelButton").GetComponent<Button>();
             CancelButton.onClick.AddListener(Close);
@@ -1010,7 +1010,7 @@ namespace PlanBuild.Blueprints
     internal class ActionAppliedOverlay
     {
         public Transform ContentHolder { get; set; }
-        public TMP_Text DisplayText { get; set; }
+        public Text DisplayText { get; set; }
         public Button OKButton { get; set; }
 
         public void Show()
@@ -1041,7 +1041,7 @@ namespace PlanBuild.Blueprints
         public void Register(Transform overlayTransform)
         {
             ContentHolder = overlayTransform;
-            DisplayText = overlayTransform.Find("DisplayText").GetComponent<TMP_Text>();
+            DisplayText = overlayTransform.Find("DisplayText").GetComponent<Text>();
             OKButton = overlayTransform.Find("OKButton").GetComponent<Button>();
             OKButton.onClick.AddListener(Close);
         }

--- a/PlanBuild/Blueprints/BlueprintGUI.cs
+++ b/PlanBuild/Blueprints/BlueprintGUI.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Linq;
 using UnityEngine;
 using UnityEngine.UI;
+using TMPro;
 
 namespace PlanBuild.Blueprints
 {
@@ -434,7 +435,7 @@ namespace PlanBuild.Blueprints
                         PlanBuildPlugin.Instance.StartCoroutine(CreateRoutine(tempBlueprint));
                     }
                     break;
-                    
+
                 case BlueprintLocation.Server:
                     if (detail != null && BlueprintManager.ServerBlueprints.TryGetValue(detail.ID, out var serverBlueprint))
                     {
@@ -463,9 +464,9 @@ namespace PlanBuild.Blueprints
                 panel.type = Image.Type.Sliced;
                 panel.material = PrefabManager.Cache.GetPrefab<Material>("litpanel");
 
-                foreach (Text txt in Window.GetComponentsInChildren<Text>(true))
+                foreach (TMP_Text txt in Window.GetComponentsInChildren<TMP_Text>(true))
                 {
-                    txt.font = GUIManager.Instance.AveriaSerifBold;
+                    txt.font = TMP_FontAsset.CreateFontAsset(GUIManager.Instance.AveriaSerif);
                 }
 
                 foreach (InputField fld in Window.GetComponentsInChildren<InputField>(true))
@@ -482,7 +483,7 @@ namespace PlanBuild.Blueprints
                     GUIManager.Instance.ApplyButtonStyle(btn);
                     if (btn.name.Equals("CreateThumbnail", StringComparison.Ordinal))
                     {
-                        btn.GetComponentInChildren<Text>(true).fontSize = 13;
+                        btn.GetComponentInChildren<TMP_Text>(true).fontSize = 13;
                     }
                 }
 
@@ -594,7 +595,7 @@ namespace PlanBuild.Blueprints
     {
         public Transform TabTransform { get; set; }
         public Button TabButton { get; set; }
-        public Text TabText { get; set; }
+        public TMP_Text TabText { get; set; }
         public GameObject TabContent { get; set; }
 
         public void Register(Transform window, string tabName, string tabText)
@@ -606,7 +607,7 @@ namespace PlanBuild.Blueprints
                 button.name = tabName;
                 TabTransform = button.transform;
                 TabButton = button.GetComponent<Button>();
-                TabText = button.transform.Find("Text").GetComponent<Text>();
+                TabText = button.transform.Find("Text").GetComponent<TMP_Text>();
                 TabContent = UnityEngine.Object.Instantiate(window.Find("TabContent").gameObject, window.Find("Content"));
                 TabContent.name = tabName;
             }
@@ -641,7 +642,7 @@ namespace PlanBuild.Blueprints
             {
                 GameObject cat = UnityEngine.Object.Instantiate(BlueprintCategoryPrefab, ScrollContentParent);
                 cat.SetActive(true);
-                cat.GetComponent<Text>().text = name;
+                cat.GetComponent<TMP_Text>().text = name;
                 Categories.Add(cat);
             }
             catch (Exception ex)
@@ -664,7 +665,7 @@ namespace PlanBuild.Blueprints
                 newBp.ContentHolder = UnityEngine.Object.Instantiate(BlueprintEntryPrefab, ScrollContentParent);
                 newBp.ContentHolder.SetActive(true);
                 newBp.Button = newBp.ContentHolder.GetComponent<Button>();
-                newBp.Text = newBp.ContentHolder.transform.Find("Text").GetComponent<Text>();
+                newBp.Text = newBp.ContentHolder.transform.Find("Text").GetComponent<TMP_Text>();
 
                 newBp.ID = bp.ID;
                 newBp.Name = bp.Name;
@@ -730,11 +731,11 @@ namespace PlanBuild.Blueprints
 
         public BlueprintDetailContent SelectedBlueprintDetail { get; set; }
 
-        public Text ID { get; set; }
-        public Text Creator { get; set; }
-        public Text Count { get; set; }
-        public Text SnapPoints { get; set; }
-        public Text TerrainMods { get; set; }
+        public TMP_Text ID { get; set; }
+        public TMP_Text Creator { get; set; }
+        public TMP_Text Count { get; set; }
+        public TMP_Text SnapPoints { get; set; }
+        public TMP_Text TerrainMods { get; set; }
         public Image Icon { get; set; }
         public InputField Name { get; set; }
         public InputField Category { get; set; }
@@ -790,11 +791,11 @@ namespace PlanBuild.Blueprints
             Name.onEndEdit.AddListener((text) => { blueprint.Name = text; });
             Category.onEndEdit.AddListener((text) => { blueprint.Category = text; });
             Description.onEndEdit.AddListener((text) => { blueprint.Description = text; });
-            
+
             CreateThumbnailButton.onClick.RemoveAllListeners();
             RotateLeftButton.onClick.RemoveAllListeners();
             RotateRightButton.onClick.RemoveAllListeners();
-                
+
             if (blueprint.Icon == null)
             {
                 CreateThumbnailButton.gameObject.SetActive(true);
@@ -817,14 +818,14 @@ namespace PlanBuild.Blueprints
                     blueprint.AdditionalRotation -= 45;
                     BlueprintGUI.Instance.CreateThumbnail(blueprint, TabType);
                 });
-                
+
                 RotateRightButton.onClick.AddListener(() =>
                 {
                     blueprint.AdditionalRotation += 45;
                     BlueprintGUI.Instance.CreateThumbnail(blueprint, TabType);
                 });
             }
-            
+
             SaveButton.onClick.RemoveAllListeners();
             TransferButton.onClick.RemoveAllListeners();
             DeleteButton.onClick.RemoveAllListeners();
@@ -859,7 +860,7 @@ namespace PlanBuild.Blueprints
             Name.onEndEdit.RemoveAllListeners();
             Category.onEndEdit.RemoveAllListeners();
             Description.onEndEdit.RemoveAllListeners();
-            
+
             CreateThumbnailButton.onClick.RemoveAllListeners();
             RotateLeftButton.onClick.RemoveAllListeners();
             RotateRightButton.onClick.RemoveAllListeners();
@@ -894,11 +895,11 @@ namespace PlanBuild.Blueprints
                 ConfirmationOverlay.Register(overlayParent);
 
                 Transform detail = contentTransform.Find("Detail");
-                ID = detail.Find("ID").GetComponent<Text>();
-                Creator = detail.Find("Creator").GetComponent<Text>();
-                Count = detail.Find("Count").GetComponent<Text>();
-                SnapPoints = detail.Find("SnapPoints").GetComponent<Text>();
-                TerrainMods = detail.Find("TerrainMods").GetComponent<Text>();
+                ID = detail.Find("ID").GetComponent<TMP_Text>();
+                Creator = detail.Find("Creator").GetComponent<TMP_Text>();
+                Count = detail.Find("Count").GetComponent<TMP_Text>();
+                SnapPoints = detail.Find("SnapPoints").GetComponent<TMP_Text>();
+                TerrainMods = detail.Find("TerrainMods").GetComponent<TMP_Text>();
                 Icon = detail.Find("Thumbnail").GetComponent<Image>();
                 Icon.gameObject.SetActive(false);
                 Name = detail.Find("Name").GetComponent<InputField>();
@@ -917,7 +918,7 @@ namespace PlanBuild.Blueprints
                 // Type dependend actions
                 if (tabType == BlueprintLocation.Local)
                 {
-                    TransferButton.GetComponentInChildren<Text>().text = "$gui_bpmarket_upload";
+                    TransferButton.GetComponentInChildren<TMP_Text>().text = "$gui_bpmarket_upload";
                 }
                 if (tabType == BlueprintLocation.Temporary)
                 {
@@ -926,7 +927,7 @@ namespace PlanBuild.Blueprints
                 }
                 if (tabType == BlueprintLocation.Server)
                 {
-                    TransferButton.GetComponentInChildren<Text>().text = "$gui_bpmarket_download";
+                    TransferButton.GetComponentInChildren<TMP_Text>().text = "$gui_bpmarket_download";
                 }
 
                 // Add valheim refresh icon
@@ -959,7 +960,7 @@ namespace PlanBuild.Blueprints
         public string SnapPoints { get; set; }
         public string TerrainMods { get; set; }
         public string Description { get; set; }
-        public Text Text { get; set; }
+        public TMP_Text Text { get; set; }
         public Sprite Icon { get; set; }
         public Button Button { get; set; }
         public int AdditionalRotation { get; set; }
@@ -968,7 +969,7 @@ namespace PlanBuild.Blueprints
     internal class UIConfirmationOverlay
     {
         public Transform ContentHolder { get; set; }
-        public Text ConfirmationDisplayText { get; set; }
+        public TMP_Text ConfirmationDisplayText { get; set; }
         public Button CancelButton { get; set; }
         public Button ConfirmButton { get; set; }
 
@@ -997,7 +998,7 @@ namespace PlanBuild.Blueprints
         public void Register(Transform overlayTransform)
         {
             ContentHolder = overlayTransform;
-            ConfirmationDisplayText = overlayTransform.Find("ConfirmText").GetComponent<Text>();
+            ConfirmationDisplayText = overlayTransform.Find("ConfirmText").GetComponent<TMP_Text>();
             ConfirmButton = overlayTransform.Find("ConfirmationButton").GetComponent<Button>();
             CancelButton = overlayTransform.Find("CancelButton").GetComponent<Button>();
             CancelButton.onClick.AddListener(Close);
@@ -1007,7 +1008,7 @@ namespace PlanBuild.Blueprints
     internal class ActionAppliedOverlay
     {
         public Transform ContentHolder { get; set; }
-        public Text DisplayText { get; set; }
+        public TMP_Text DisplayText { get; set; }
         public Button OKButton { get; set; }
 
         public void Show()
@@ -1038,7 +1039,7 @@ namespace PlanBuild.Blueprints
         public void Register(Transform overlayTransform)
         {
             ContentHolder = overlayTransform;
-            DisplayText = overlayTransform.Find("DisplayText").GetComponent<Text>();
+            DisplayText = overlayTransform.Find("DisplayText").GetComponent<TMP_Text>();
             OKButton = overlayTransform.Find("OKButton").GetComponent<Button>();
             OKButton.onClick.AddListener(Close);
         }

--- a/PlanBuild/Blueprints/BlueprintManager.cs
+++ b/PlanBuild/Blueprints/BlueprintManager.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Linq;
 using UnityEngine;
 using UnityEngine.UI;
+using TMPro;
 using Logger = Jotunn.Logger;
 
 namespace PlanBuild.Blueprints
@@ -443,13 +444,13 @@ namespace PlanBuild.Blueprints
                     bp.Thumbnail != null)
                 {
                     self.m_tooltipPrefab = BlueprintAssets.BlueprintTooltip;
-                    orig(self,go);
+                    orig(self, go);
                     global::Utils.FindChild(UITooltip.m_tooltip.transform, "Background")
                         .GetComponent<Image>().color = Config.TooltipBackgroundConfig.Value;
                     global::Utils.FindChild(UITooltip.m_tooltip.transform, "BPImage")
                         .GetComponent<Image>().sprite = Sprite.Create(bp.Thumbnail, new Rect(0, 0, bp.Thumbnail.width, bp.Thumbnail.height), Vector2.zero);
                     global::Utils.FindChild(UITooltip.m_tooltip.transform, "BPText")
-                        .GetComponent<Text>().text = bp.Name;
+                        .GetComponent<TMP_Text>().text = bp.Name;
                 }
                 else
                 {

--- a/PlanBuild/Blueprints/BlueprintManager.cs
+++ b/PlanBuild/Blueprints/BlueprintManager.cs
@@ -6,7 +6,7 @@ using System.Collections.Generic;
 using System.Linq;
 using UnityEngine;
 using UnityEngine.UI;
-using TMPro;
+
 using Logger = Jotunn.Logger;
 
 namespace PlanBuild.Blueprints
@@ -450,7 +450,7 @@ namespace PlanBuild.Blueprints
                     global::Utils.FindChild(UITooltip.m_tooltip.transform, "BPImage")
                         .GetComponent<Image>().sprite = Sprite.Create(bp.Thumbnail, new Rect(0, 0, bp.Thumbnail.width, bp.Thumbnail.height), Vector2.zero);
                     global::Utils.FindChild(UITooltip.m_tooltip.transform, "BPText")
-                        .GetComponent<TMP_Text>().text = bp.Name;
+                        .GetComponent<Text>().text = bp.Name;
                 }
                 else
                 {

--- a/PlanBuild/Blueprints/SelectionGUI.cs
+++ b/PlanBuild/Blueprints/SelectionGUI.cs
@@ -1,10 +1,9 @@
 ﻿using Jotunn.GUI;
 using Jotunn.Managers;
 using System;
-using System.Linq;
+using TMPro;
 using UnityEngine;
 using UnityEngine.UI;
-using Object = UnityEngine.Object;
 
 namespace PlanBuild.Blueprints
 {
@@ -89,17 +88,17 @@ namespace PlanBuild.Blueprints
                 panel.sprite = GUIManager.Instance.GetSprite("woodpanel_settings");
                 panel.type = Image.Type.Sliced;
                 panel.material = PrefabManager.Cache.GetPrefab<Material>("litpanel");
-                
-                foreach (Text txt in Window.GetComponentsInChildren<Text>(true))
+
+                foreach (TMP_Text txt in Window.GetComponentsInChildren<TMP_Text>(true))
                 {
-                    txt.font = GUIManager.Instance.AveriaSerifBold;
+                    txt.font = TMP_FontAsset.CreateFontAsset(GUIManager.Instance.AveriaSerif);
                 }
 
                 foreach (Button btn in Window.GetComponentsInChildren<Button>(true))
                 {
                     GUIManager.Instance.ApplyButtonStyle(btn);
                 }
-                
+
                 foreach (Toggle tgl in Window.GetComponentsInChildren<Toggle>(true))
                 {
                     GUIManager.Instance.ApplyToogleStyle(tgl);
@@ -120,14 +119,14 @@ namespace PlanBuild.Blueprints
                 ClearButton.onClick.AddListener(() => OnClick(Clear));
                 CancelButton = Window.transform.Find("CancelButton").GetComponent<Button>();
                 CancelButton.onClick.AddListener(() => OnClick(Cancel));
-                
+
                 void OnClick(Action action)
                 {
                     action?.Invoke();
                     Window.SetActive(false);
                     GUIManager.BlockInput(false);
                 }
-                
+
                 // Localize
                 Localization.instance.Localize(Instance.Window.transform);
 
@@ -138,7 +137,7 @@ namespace PlanBuild.Blueprints
                 Window.SetActive(false);
             }
         }
-        
+
         private void Cancel()
         {
             Window.SetActive(false);
@@ -153,20 +152,20 @@ namespace PlanBuild.Blueprints
                 {
                     return;
                 }
-                
+
                 if (Input.GetKeyUp(KeyCode.Escape))
                 {
                     Instance.Cancel();
                 }
             }
         }
-        
+
         private void Copy()
         {
             SelectionTools.Copy(Selection.Instance, SnapPointsToggle.isOn, MarkersToggle.isOn);
             Selection.Instance.Clear();
         }
-        
+
         private void Cut()
         {
             if (!SynchronizationManager.Instance.PlayerIsAdmin)
@@ -178,12 +177,12 @@ namespace PlanBuild.Blueprints
             SelectionTools.Cut(Selection.Instance, SnapPointsToggle.isOn, MarkersToggle.isOn);
             Selection.Instance.Clear();
         }
-        
+
         private void SaveGUI()
         {
             SelectionTools.SaveWithGUI(Selection.Instance, SnapPointsToggle.isOn, MarkersToggle.isOn);
         }
-        
+
         private void Delete()
         {
             if (!SynchronizationManager.Instance.PlayerIsAdmin)

--- a/PlanBuild/Blueprints/SelectionSaveGUI.cs
+++ b/PlanBuild/Blueprints/SelectionSaveGUI.cs
@@ -4,6 +4,7 @@ using System;
 using System.Linq;
 using UnityEngine;
 using UnityEngine.UI;
+using TMPro;
 
 namespace PlanBuild.Blueprints
 {
@@ -13,10 +14,10 @@ namespace PlanBuild.Blueprints
 
         private GameObject Prefab;
         private GameObject Window;
-        private Text Pieces;
-        private Text SnapPoints;
-        private Text CenterMarkers;
-        private Text TerrainMods;
+        private TMP_Text Pieces;
+        private TMP_Text SnapPoints;
+        private TMP_Text CenterMarkers;
+        private TMP_Text TerrainMods;
         private InputField Name;
         private InputField Category;
         private InputField Description;
@@ -98,9 +99,9 @@ namespace PlanBuild.Blueprints
                 panel.type = Image.Type.Sliced;
                 panel.material = PrefabManager.Cache.GetPrefab<Material>("litpanel");
 
-                foreach (Text txt in Window.GetComponentsInChildren<Text>(true))
+                foreach (TMP_Text txt in Window.GetComponentsInChildren<TMP_Text>(true))
                 {
-                    txt.font = GUIManager.Instance.AveriaSerifBold;
+                    txt.font = TMP_FontAsset.CreateFontAsset(GUIManager.Instance.AveriaSerif);
                 }
 
                 foreach (InputField fld in Window.GetComponentsInChildren<InputField>(true))
@@ -114,10 +115,10 @@ namespace PlanBuild.Blueprints
                 }
 
                 // Register Components
-                Pieces = Window.transform.Find("Details/Pieces").GetComponent<Text>();
-                CenterMarkers = Window.transform.Find("Details/CenterMarkers").GetComponent<Text>();
-                SnapPoints = Window.transform.Find("Details/SnapPoints").GetComponent<Text>();
-                TerrainMods = Window.transform.Find("Details/TerrainMods").GetComponent<Text>();
+                Pieces = Window.transform.Find("Details/Pieces").GetComponent<TMP_Text>();
+                CenterMarkers = Window.transform.Find("Details/CenterMarkers").GetComponent<TMP_Text>();
+                SnapPoints = Window.transform.Find("Details/SnapPoints").GetComponent<TMP_Text>();
+                TerrainMods = Window.transform.Find("Details/TerrainMods").GetComponent<TMP_Text>();
                 Name = Window.transform.Find("Name/InputField").GetComponent<InputField>();
                 Name.textComponent.alignment = TextAnchor.MiddleLeft;
                 Category = Window.transform.Find("Category/InputField").GetComponent<InputField>();

--- a/PlanBuild/Blueprints/TerrainModGUI.cs
+++ b/PlanBuild/Blueprints/TerrainModGUI.cs
@@ -3,6 +3,7 @@ using Jotunn.Managers;
 using System;
 using UnityEngine;
 using UnityEngine.UI;
+using TMPro;
 
 namespace PlanBuild.Blueprints
 {
@@ -64,7 +65,7 @@ namespace PlanBuild.Blueprints
         {
             OkAction = okAction;
             CancelAction = cancelAction;
-            
+
             Shape.value = Shape.options.FindIndex(x => x.text.Equals(shape, StringComparison.OrdinalIgnoreCase));
             Radius.text = radius;
             Rotation.text = rotation;
@@ -92,9 +93,9 @@ namespace PlanBuild.Blueprints
                 panel.type = Image.Type.Sliced;
                 panel.material = PrefabManager.Cache.GetPrefab<Material>("litpanel");
 
-                foreach (Text txt in Window.GetComponentsInChildren<Text>(true))
+                foreach (TMP_Text txt in Window.GetComponentsInChildren<TMP_Text>(true))
                 {
-                    txt.font = GUIManager.Instance.AveriaSerifBold;
+                    txt.font = TMP_FontAsset.CreateFontAsset(GUIManager.Instance.AveriaSerif);
                 }
 
                 foreach (Dropdown dwn in Window.GetComponentsInChildren<Dropdown>(true))

--- a/PlanBuild/PlanBuild.csproj
+++ b/PlanBuild/PlanBuild.csproj
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\packages\JotunnLib.2.14.3\build\JotunnLib.props" Condition="Exists('..\packages\JotunnLib.2.14.3\build\JotunnLib.props')" />
+  <Import Project="..\packages\JotunnLib.2.14.4\build\JotunnLib.props" Condition="Exists('..\packages\JotunnLib.2.14.4\build\JotunnLib.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -60,8 +60,8 @@
       <HintPath>..\libraries\pub\ComfyGizmo.dll</HintPath>
       <Private>False</Private>
     </Reference>
-    <Reference Include="Jotunn, Version=2.14.3.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\JotunnLib.2.14.3\lib\net462\Jotunn.dll</HintPath>
+    <Reference Include="Jotunn, Version=2.14.4.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\JotunnLib.2.14.4\lib\net462\Jotunn.dll</HintPath>
     </Reference>
     <Reference Include="ValheimRAFT">
       <SpecificVersion>False</SpecificVersion>
@@ -231,6 +231,6 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\JotunnLib.2.14.3\build\JotunnLib.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\JotunnLib.2.14.3\build\JotunnLib.props'))" />
+    <Error Condition="!Exists('..\packages\JotunnLib.2.14.4\build\JotunnLib.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\JotunnLib.2.14.4\build\JotunnLib.props'))" />
   </Target>
 </Project>

--- a/PlanBuild/Plans/PlanPiece.cs
+++ b/PlanBuild/Plans/PlanPiece.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.UI;
+using TMPro;
 using static Piece;
 
 namespace PlanBuild.Plans
@@ -281,8 +282,8 @@ namespace PlanBuild.Plans
                 GameObject obj = uiRequirementPanels[piece.m_resources.Length];
                 obj.SetActive(value: true);
                 Image component = obj.transform.Find("res_icon").GetComponent<Image>();
-                Text component2 = obj.transform.Find("res_name").GetComponent<Text>();
-                Text component3 = obj.transform.Find("res_amount").GetComponent<Text>();
+                TMP_Text component2 = obj.transform.Find("res_name").GetComponent<TMP_Text>();
+                TMP_Text component3 = obj.transform.Find("res_amount").GetComponent<TMP_Text>();
                 UITooltip component4 = obj.GetComponent<UITooltip>();
                 component.sprite = piece.m_craftingStation.m_icon;
                 component2.text = Localization.instance.Localize(piece.m_craftingStation.m_name);
@@ -306,8 +307,8 @@ namespace PlanBuild.Plans
         public bool SetupRequirement(Transform elementRoot, Requirement req, int currentAmount)
         {
             Image imageResIcon = elementRoot.transform.Find("res_icon").GetComponent<Image>();
-            Text textResName = elementRoot.transform.Find("res_name").GetComponent<Text>();
-            Text textResAmount = elementRoot.transform.Find("res_amount").GetComponent<Text>();
+            TMP_Text textResName = elementRoot.transform.Find("res_name").GetComponent<TMP_Text>();
+            TMP_Text textResAmount = elementRoot.transform.Find("res_amount").GetComponent<TMP_Text>();
             UITooltip uiTooltip = elementRoot.GetComponent<UITooltip>();
             if (req.m_resItem != null)
             {
@@ -377,7 +378,7 @@ namespace PlanBuild.Plans
                 Build(player.GetPlayerID());
                 return false;
             }
-            
+
             if (hold)
             {
                 if (Time.time - m_lastUseTime < m_holdRepeatInterval)
@@ -443,7 +444,7 @@ namespace PlanBuild.Plans
         {
             return hasSupport;
         }
-        
+
         public void Build(long playerID)
         {
             m_nView.InvokeRPC("Refund", false);

--- a/PlanBuild/packages.config
+++ b/PlanBuild/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="HarmonyX" version="2.9.0" targetFramework="net48" />
-  <package id="JotunnLib" version="2.14.3" targetFramework="net48" />
+  <package id="JotunnLib" version="2.14.4" targetFramework="net48" />
   <package id="Mono.Cecil" version="0.11.4" targetFramework="net48" />
   <package id="MonoMod" version="21.9.19.1" targetFramework="net48" />
   <package id="MonoMod.RuntimeDetour" version="22.1.29.1" targetFramework="net48" />


### PR DESCRIPTION
Hey, this pull request should fix the null reference exceptions PlanBuild has on the current patch of the game. In the current patch the devs switched to using TextMeshPro for in-game text so I've changed all references to the type <Text> to <TMP_Text> when retrieving text information from game objects. When retrieving information from blueprint files or in the custom GUI of PlanBuild it still uses <Text> as trying to change that to <TMP_Text> caused a new set of null reference exceptions. 

Note: The recent force pushes are due to me fixing the author of the commits.