### PR TITLE
Public API for updating PlanHammer piece table to help Mod Compatiability

### DIFF
--- a/PlanBuild/PlanBuildPlugin.cs
+++ b/PlanBuild/PlanBuildPlugin.cs
@@ -30,12 +30,12 @@ namespace PlanBuild
         public const string PluginVersion = "0.14.7";
 
         public static PlanBuildPlugin Instance;
-        
+
         public void Awake()
         {
             Instance = this;
             Assembly assembly = typeof(PlanBuildPlugin).Assembly;
-            
+
             // Init config
             PlanBuild.Config.Init();
 
@@ -59,7 +59,7 @@ namespace PlanBuild
             // Harmony patching
             Patches.Apply();
         }
-        
+
         public void Update()
         {
             // No keys without ZInput
@@ -75,7 +75,7 @@ namespace PlanBuild
             }
 
             // BP Market GUI is OK in the main menu
-            if (BlueprintGUI.IsAvailable() && 
+            if (BlueprintGUI.IsAvailable() &&
                 !SelectionSaveGUI.IsVisible() && !TerrainModGUI.IsVisible() && !SelectionGUI.IsVisible() &&
                 (PlanBuild.Config.AllowMarketHotkey.Value || SynchronizationManager.Instance.PlayerIsAdmin) &&
                 ZInput.GetButtonDown(PlanBuild.Config.MarketHotkeyButton.Name))
@@ -89,6 +89,15 @@ namespace PlanBuild
                 BlueprintGUI.Instance.Toggle(shutWindow: true);
                 ZInput.ResetButtonStatus("Use");
             }
+        }
+
+        /// <summary>
+        ///     Public API method so mods that add/remove pieces in-game can 
+        ///     trigger PlanBuild to update the PlanHammer piece table. 
+        /// </summary>
+        public void UpdateScanPieces()
+        {
+            PlanDB.Instance.ScanPieceTables();
         }
     }
 }

--- a/PlanBuild/Plans/PlanDB.cs
+++ b/PlanBuild/Plans/PlanDB.cs
@@ -22,6 +22,16 @@ namespace PlanBuild.Plans
             }
         }
 
+        /// <summary>
+        ///     Checks if a piece table is valid for creating plan pieces from
+        /// </summary>
+        /// <param name="pieceTable"></param>
+        /// <returns></returns>
+        private static bool IsValidPieceTable(PieceTable pieceTable)
+        {
+            return pieceTable && !pieceTable.name.Equals(PlanHammerPrefab.PieceTableName) && !pieceTable.name.Equals(BlueprintAssets.PieceTableName);
+        }
+
         public readonly Dictionary<string, Piece> PlanToOriginalMap = new Dictionary<string, Piece>();
         public readonly Dictionary<string, PlanPiecePrefab> PlanPiecePrefabs = new Dictionary<string, PlanPiecePrefab>();
 

--- a/PlanBuild/Plans/PlanDB.cs
+++ b/PlanBuild/Plans/PlanDB.cs
@@ -107,8 +107,8 @@ namespace PlanBuild.Plans
                 }
             }
 
-            // Update plan pieces to match original pieces
-            // Add/remove plan pieces that have been added/removed
+            // Handle which plan pieces are shown in the PlanHammer piece table and update
+            // existing plan pieces to reflect changes in original pieces
             foreach (string pieceName in PlanPiecePrefabs.Keys)
             {
                 try
@@ -118,6 +118,8 @@ namespace PlanBuild.Plans
                     {
                         planPiece.Piece.m_enabled = orgPiece.m_enabled;
                         planPiece.Piece.m_icon = orgPiece.m_icon;
+                        // update Icon for MVBP and WackyDB, or other mods
+                        // that create icons when adding/creating pieces at runtime
 
                         if (orgPiece.m_enabled)
                         {

--- a/PlanBuild/Plans/PlanDB.cs
+++ b/PlanBuild/Plans/PlanDB.cs
@@ -134,8 +134,11 @@ namespace PlanBuild.Plans
                     }
 
                     planPiece.Piece.m_enabled = false;
-                    planPieceTable.m_pieces.Remove(planPiece.PiecePrefab);
-                    PieceManager.Instance.RemovePiece(planPiece);
+                    if (planPieceTable.m_pieces.Contains(planPiece.PiecePrefab))
+                    {
+                        planPieceTable.m_pieces.Remove(planPiece.PiecePrefab);
+                        PieceManager.Instance.RemovePiece(planPiece);
+                    }
                 }
                 catch (Exception e)
                 {


### PR DESCRIPTION
As discussed in the past, `PlanBuild` currently can't detect when other mods like `MoreVanillaBuildPrefabs` add/remove pieces in-game. Rather than requiring `PlanBuild` to constantly rescan pieces the idea of simply exposing the `ScanPieceTables` methods through a public API was proposed to mods like `MoreVanillaBuildPrefabs` could update `PlanBuild` as needed and the onus of compatibility could be placed on mods that add/remove pieces while in-game. 

This PR adds a public API method to the main plugin that simply calls `PlanDB.Instance.ScanPieceTables` and I also rewrote the method `ScanPieceTables` to separate the process of creating PlanPieces and the process of managing the PlanHammer piece table. This way PlanPieces are only ever created once and pre-existing PlanPieces are left alone when rescanning piece tables but the PlanHammer piece table can still be updated.