### PR TITLE
Handle non-unique prefab errors

### DIFF
--- a/PlanBuild/Plans/PlanDB.cs
+++ b/PlanBuild/Plans/PlanDB.cs
@@ -65,14 +65,22 @@ namespace PlanBuild.Plans
                         Logger.LogWarning($"Prefab {piecePrefab.name} has no Piece?!");
                         continue;
                     }
-                    piecesDict.Add(piece.name, piece);
+                    if (piece.name == "piece_repair")
+                    {
+                        continue;
+                    }
+                    if (piecesDict.ContainsKey(piece.name))
+                    {
+                        Logger.LogWarning($"Prefab {piece.name} is not unique?!")
+                    }
+                    else
+                    {
+                        piecesDict.Add(piece.name, piece);
+                    }
+
 
                     try
                     {
-                        if (piece.name == "piece_repair")
-                        {
-                            continue;
-                        }
                         if (PlanPiecePrefabs.ContainsKey(piece.name))
                         {
                             continue;

--- a/PlanBuild/Plans/PlanDB.cs
+++ b/PlanBuild/Plans/PlanDB.cs
@@ -71,7 +71,8 @@ namespace PlanBuild.Plans
                     }
                     if (piecesDict.ContainsKey(piece.name))
                     {
-                        Logger.LogWarning($"Prefab {piece.name} is not unique?!")
+                        Logger.LogWarning($"Prefab {piece.name} is not unique?!");
+                        continue;
                     }
                     else
                     {


### PR DESCRIPTION
This should properly handle non-unique prefab pieces added by mods and throw a warning about it (though it will ignore piece_repair pieces)