### PR TITLE
Handle piece removal at runtime

### DIFF
--- a/PlanBuild/Plans/PlanDB.cs
+++ b/PlanBuild/Plans/PlanDB.cs
@@ -73,8 +73,16 @@ namespace PlanBuild.Plans
                     }
 
                     // Track which pieces are currently in a piece table as sometimes
-                    // a Vanilla prefab can have a piece but not be in a piecee table
-                    currentPieces.Add(piece.name);
+                    // a Vanilla prefab can have a piece but not be in a piece table
+                    if (currentPieces.Contains(piece.name))
+                    {
+                        Logger.LogDebug($"Multiple prefabs with name: {piece.name}");
+                    }
+                    else
+                    {
+                        currentPieces.Add(piece.name);
+                    }
+
 
                     try
                     {


### PR DESCRIPTION
Looks like the issue had to do with how there are Vanilla prefabs that have a piece component that are enabled by default so even though I have removed them from the Vanilla hammer (after I added them) PlanBuild still knows they exist and that they are enabled, so it was added them back to the PlanHammer piece table. 

To solve this I added a HashSet that is used to track which pieces are in a PieceTable when the ScanPieceTables method is triggered and when going through all the plan pieces it now checks if that HashSet contains the name of the original piece before adding it to the PlanHammer piece table. 