### PR TITLE
Bhearus v0.218.21 blueprint loading fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Version 0.17.0
+* Compatible with Valheim v0.218.21
+* Fixed OnPlayer Spawn for blueprint loading.
+
 # Version 0.16.0
 * Compatible with Valheim v0.218.15
 * Fixed unsupported PlanPieces disappearing

--- a/PlanBuild/Blueprints/BlueprintManager.cs
+++ b/PlanBuild/Blueprints/BlueprintManager.cs
@@ -233,9 +233,9 @@ namespace PlanBuild.Blueprints
         /// <summary>
         ///     Create blueprint pieces on player spawn
         /// </summary>
-        private static void Player_OnSpawned(On.Player.orig_OnSpawned orig, Player self)
+        private static void Player_OnSpawned(On.Player.orig_OnSpawned orig, Player self, bool spawnValkrie)
         {
-            orig(self);
+            orig(self, spawnValkrie);
             if (self == Player.m_localPlayer)
             {
                 RegisterKnownBlueprints();

--- a/PlanBuild/PlanBuildPlugin.cs
+++ b/PlanBuild/PlanBuildPlugin.cs
@@ -27,7 +27,7 @@ namespace PlanBuild
     {
         public const string PluginGUID = "marcopogo.PlanBuild";
         public const string PluginName = "PlanBuild";
-        public const string PluginVersion = "0.16.0";
+        public const string PluginVersion = "0.17.0";
 
         public static PlanBuildPlugin Instance;
 

--- a/PlanBuild/Properties/AssemblyInfo.cs
+++ b/PlanBuild/Properties/AssemblyInfo.cs
@@ -28,5 +28,5 @@ using System.Runtime.InteropServices;
 //      Build Number
 //      Revision
 //
-[assembly: AssemblyVersion("0.16.0.0")]
-[assembly: AssemblyFileVersion("0.16.0.0")]
+[assembly: AssemblyVersion("0.17.0.0")]
+[assembly: AssemblyFileVersion("0.17.0.0")]

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "PlanBuild",
   "description": "PlanBuild enables you to plan, copy and share your building creations in Valheim with ease. Includes terrain tools and immersion items.",
-  "version_number": "0.16.0",
+  "version_number": "0.17.0",
   "dependencies": [
     "denikson-BepInExPack_Valheim-5.4.2202",
     "ValheimModding-Jotunn-2.20.1",


### PR DESCRIPTION
# Version 0.17.0
* Compatible with Valheim v0.218.21
* Fixed OnPlayer Spawn for blueprint loading.