### PR TITLE
Make PlanBuild compatible with Valheim v0.219.14 (Bog Witch)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# Version 0.18.0
+* Compatible with Valheim 0.219.14 (Bog Witch)
+
 # Version 0.17.0
 * Compatible with Valheim v0.218.21
 * Fixed OnPlayer Spawn for blueprint loading (thx Bhearus).

--- a/PlanBuild/Blueprints/Components/ToolComponentBase.cs
+++ b/PlanBuild/Blueprints/Components/ToolComponentBase.cs
@@ -34,7 +34,7 @@ namespace PlanBuild.Blueprints.Components
 
             On.Player.UpdatePlacement += Player_UpdatePlacement;
             On.Player.UpdateWearNTearHover += Player_UpdateWearNTearHover;
-            On.Player.PlacePiece += Player_PlacePiece;
+            On.Player.TryPlacePiece += Player_TryPlacePiece;
 
             On.Player.UpdatePlacementGhost += Player_UpdatePlacementGhost;
             On.Player.PieceRayTest += Player_PieceRayTest;
@@ -62,7 +62,7 @@ namespace PlanBuild.Blueprints.Components
 
             On.Player.UpdatePlacement -= Player_UpdatePlacement;
             On.Player.UpdateWearNTearHover -= Player_UpdateWearNTearHover;
-            On.Player.PlacePiece -= Player_PlacePiece;
+            On.Player.TryPlacePiece -= Player_TryPlacePiece;
 
             On.Player.UpdatePlacementGhost -= Player_UpdatePlacementGhost;
             On.Player.PieceRayTest -= Player_PieceRayTest;
@@ -283,7 +283,7 @@ namespace PlanBuild.Blueprints.Components
         ///     Incept placing of the meta pieces.
         ///     Cancels the real placement of the placeholder pieces.
         /// </summary>
-        private bool Player_PlacePiece(On.Player.orig_PlacePiece orig, Player self, Piece piece)
+        private bool Player_TryPlacePiece(On.Player.orig_TryPlacePiece orig, Player self, Piece piece)
         {
             OnPlacePiece(self, piece);
             return false;

--- a/PlanBuild/Blueprints/TerrainTools.cs
+++ b/PlanBuild/Blueprints/TerrainTools.cs
@@ -62,8 +62,7 @@ namespace PlanBuild.Blueprints
             List<Heightmap> heightMaps = new List<Heightmap>();
             Heightmap.FindHeightmap(position, radius + 1f, heightMaps);
             var pos = position;
-            var zs = ZoneSystem.instance;
-            return heightMaps.Where(hmap => ZNetScene.InActiveArea(zs.GetZone(hmap.transform.position), pos))
+            return heightMaps.Where(hmap => ZNetScene.InActiveArea(ZoneSystem.GetZone(hmap.transform.position), pos))
                 .Select(hmap => hmap.GetAndCreateTerrainCompiler());
         }
 
@@ -78,9 +77,8 @@ namespace PlanBuild.Blueprints
             var size = maxDimension * dimensionMultiplier / 2f;
             Heightmap.FindHeightmap(position, size + 1f, heightMaps);
             var pos = position;
-            var zs = ZoneSystem.instance;
             var ns = ZNetScene.instance;
-            return heightMaps.Where(hmap => ZNetScene.InActiveArea(zs.GetZone(hmap.transform.position), pos))
+            return heightMaps.Where(hmap => ZNetScene.InActiveArea(ZoneSystem.GetZone(hmap.transform.position), pos))
                 .Select(hmap => hmap.GetAndCreateTerrainCompiler());
         }
 

--- a/PlanBuild/PlanBuildPlugin.cs
+++ b/PlanBuild/PlanBuildPlugin.cs
@@ -16,7 +16,7 @@ using ShaderHelper = PlanBuild.Utils.ShaderHelper;
 namespace PlanBuild
 {
     [BepInPlugin(PluginGUID, PluginName, PluginVersion)]
-    [BepInDependency(Jotunn.Main.ModGuid, "2.19.2")]
+    [BepInDependency(Jotunn.Main.ModGuid, "2.21.3")]
     [BepInDependency(Patches.BuildCameraGUID, BepInDependency.DependencyFlags.SoftDependency)]
     [BepInDependency(Patches.CraftFromContainersGUID, BepInDependency.DependencyFlags.SoftDependency)]
     [BepInDependency(Patches.GizmoGUID, BepInDependency.DependencyFlags.SoftDependency)]
@@ -27,7 +27,7 @@ namespace PlanBuild
     {
         public const string PluginGUID = "marcopogo.PlanBuild";
         public const string PluginName = "PlanBuild";
-        public const string PluginVersion = "0.17.0";
+        public const string PluginVersion = "0.17.1";
 
         public static PlanBuildPlugin Instance;
 

--- a/PlanBuild/PlanBuildPlugin.cs
+++ b/PlanBuild/PlanBuildPlugin.cs
@@ -16,7 +16,7 @@ using ShaderHelper = PlanBuild.Utils.ShaderHelper;
 namespace PlanBuild
 {
     [BepInPlugin(PluginGUID, PluginName, PluginVersion)]
-    [BepInDependency(Jotunn.Main.ModGuid, "2.21.3")]
+    [BepInDependency(Jotunn.Main.ModGuid, "2.21.2")]
     [BepInDependency(Patches.BuildCameraGUID, BepInDependency.DependencyFlags.SoftDependency)]
     [BepInDependency(Patches.CraftFromContainersGUID, BepInDependency.DependencyFlags.SoftDependency)]
     [BepInDependency(Patches.GizmoGUID, BepInDependency.DependencyFlags.SoftDependency)]
@@ -27,7 +27,7 @@ namespace PlanBuild
     {
         public const string PluginGUID = "marcopogo.PlanBuild";
         public const string PluginName = "PlanBuild";
-        public const string PluginVersion = "0.17.1";
+        public const string PluginVersion = "0.18.0";
 
         public static PlanBuildPlugin Instance;
 

--- a/PlanBuild/Plans/PlanHammerPrefab.cs
+++ b/PlanBuild/Plans/PlanHammerPrefab.cs
@@ -149,13 +149,13 @@ namespace PlanBuild.Plans
             private void Start()
             {
                 On.Player.PieceRayTest += Player_PieceRayTest;
-                On.Player.PlacePiece += Player_PlacePiece;
+                On.Player.TryPlacePiece += Player_TryPlacePiece;
                 Logger.LogDebug($"{gameObject.name} started");
             }
             
             private void OnDestroy()
             {
-                On.Player.PlacePiece -= Player_PlacePiece;
+                On.Player.TryPlacePiece -= Player_TryPlacePiece;
                 On.Player.PieceRayTest -= Player_PieceRayTest;
                 Logger.LogDebug($"{gameObject.name} destroyed");
             }
@@ -167,7 +167,7 @@ namespace PlanBuild.Plans
                 return result;
             }
 
-            private bool Player_PlacePiece(On.Player.orig_PlacePiece orig, Player self, Piece piece)
+            private bool Player_TryPlacePiece(On.Player.orig_TryPlacePiece orig, Player self, Piece piece)
             {
                 if (LastHoveredPiece && LastHoveredPiece.TryGetComponent(out PlanPiece planPiece))
                 {

--- a/PlanBuild/Plans/PlanManager.cs
+++ b/PlanBuild/Plans/PlanManager.cs
@@ -217,7 +217,7 @@ namespace PlanBuild.Plans
             orig(self);
         }
         
-        private static void WearNTear_Destroy(On.WearNTear.orig_Destroy orig, WearNTear wearNTear, HitData hitData)
+        private static void WearNTear_Destroy(On.WearNTear.orig_Destroy orig, WearNTear wearNTear, HitData hitData, bool blockDrop)
         {
             // Check if actually destoyed, not removed by middle clicking with Hammer
             if (wearNTear.m_nview && wearNTear.m_nview.IsOwner()
@@ -238,7 +238,7 @@ namespace PlanBuild.Plans
                     }
                 }
             }
-            orig(wearNTear, hitData);
+            orig(wearNTear, hitData, blockDrop);
         }
     }
 }

--- a/PlanBuild/Properties/AssemblyInfo.cs
+++ b/PlanBuild/Properties/AssemblyInfo.cs
@@ -28,5 +28,5 @@ using System.Runtime.InteropServices;
 //      Build Number
 //      Revision
 //
-[assembly: AssemblyVersion("0.17.0.0")]
-[assembly: AssemblyFileVersion("0.17.0.0")]
+[assembly: AssemblyVersion("0.18.0.0")]
+[assembly: AssemblyFileVersion("0.18.0.0")]

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "PlanBuild",
   "description": "PlanBuild enables you to plan, copy and share your building creations in Valheim with ease. Includes terrain tools and immersion items.",
-  "version_number": "0.17.0",
+  "version_number": "0.18.0",
   "dependencies": [
     "denikson-BepInExPack_Valheim-5.4.2202",
     "ValheimModding-Jotunn-2.20.3",


### PR DESCRIPTION
fixes #101 
fixes #102  

**Changes**
- Adhere to new interfaces
- Require at least Jotunn v2.21.2 (Bog Witch compatibility)
- Bump project version to v0.18.0
- Update changelog

**Release-Builds**
- [PlanBuild-0.18.0.0.zip](https://github.com/user-attachments/files/17637800/PlanBuild-0.18.0.0.zip)
- [PlanBuild-0.18.0.0-nexus.zip](https://github.com/user-attachments/files/17637802/PlanBuild-0.18.0.0-nexus.zip)
- [PlanBuild-0.18.0.0-tsio.zip](https://github.com/user-attachments/files/17637803/PlanBuild-0.18.0.0-tsio.zip)
