### PR TITLE
Fix various material highlight issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# Version 0.18.1
+* Fixed highlighting materials after equipping blueprint rune
+* Fixed unhighlighting material after deselecting it / unequipping blueprint rune
+* Fixed incorrect selection highlighting after (un)equpping Skuld Crystal
+* Fixed unintentional overwriting of original material data
+
 # Version 0.18.0
 * Compatible with Valheim 0.219.14 (Bog Witch) (ths sea212)
 

--- a/PlanBuild/Blueprints/Selection.cs
+++ b/PlanBuild/Blueprints/Selection.cs
@@ -289,8 +289,6 @@ namespace PlanBuild.Blueprints
 #endif
                     PlanBuildPlugin.Instance.StopCoroutine(UnhighlightCoroutine);
                     UnhighlightCoroutine = null;
-                    //Selection is still highlighted
-                    yield break;
                 }
 #if DEBUG
                 Logger.LogInfo($"{Time.frameCount} Starting highlight coroutine");
@@ -298,10 +296,10 @@ namespace PlanBuild.Blueprints
                 int n = 0;
                 foreach (ZDOID zdoid in new List<ZDOID>(this))
                 {
-                    //Iterating over a copy of the list to avoid ConcurrentModificationEcveption
+                    // Iterating over a copy of the list to avoid ConcurrentModificationException
                     if (!SelectedZDOIDs.Contains(zdoid))
                     {
-                        //Piece was unselected while still highlighting
+                        // Piece was unselected while still highlighting
                         continue;
                     }
                     GameObject selected = BlueprintManager.GetGameObject(zdoid);
@@ -385,7 +383,7 @@ namespace PlanBuild.Blueprints
             }
             if (gameObject && gameObject.TryGetComponent(out WearNTear wearNTear))
             {
-                wearNTear.ResetHighlight();
+                Extensions.ResetHighlight(wearNTear);
             }
             HighlightedZDOIDs.Remove(zdoid);
         }

--- a/PlanBuild/PlanBuildPlugin.cs
+++ b/PlanBuild/PlanBuildPlugin.cs
@@ -27,7 +27,7 @@ namespace PlanBuild
     {
         public const string PluginGUID = "marcopogo.PlanBuild";
         public const string PluginName = "PlanBuild";
-        public const string PluginVersion = "0.18.0";
+        public const string PluginVersion = "0.18.1";
 
         public static PlanBuildPlugin Instance;
 

--- a/PlanBuild/Plans/PlanPiece.cs
+++ b/PlanBuild/Plans/PlanPiece.cs
@@ -202,13 +202,13 @@ namespace PlanBuild.Plans
 
         internal void UpdateTextures()
         {
-            bool selected = Selection.Instance.Contains(m_piece);
-            if (selected)
+            bool highlighted = Selection.Instance.IsHighlighted(m_piece);
+            if (highlighted)
             {
                 Selection.Instance.Unhighlight(m_piece.GetZDOID().Value, gameObject);
             }
             ShaderHelper.UpdateTextures(gameObject, GetShaderState());
-            if (selected)
+            if (highlighted)
             {
                 Selection.Instance.Highlight(m_piece.GetZDOID().Value, gameObject);
             }

--- a/PlanBuild/Properties/AssemblyInfo.cs
+++ b/PlanBuild/Properties/AssemblyInfo.cs
@@ -28,5 +28,5 @@ using System.Runtime.InteropServices;
 //      Build Number
 //      Revision
 //
-[assembly: AssemblyVersion("0.18.0.0")]
-[assembly: AssemblyFileVersion("0.18.0.0")]
+[assembly: AssemblyVersion("0.18.1.0")]
+[assembly: AssemblyFileVersion("0.18.1.0")]

--- a/PlanBuild/Utils/ShaderHelper.cs
+++ b/PlanBuild/Utils/ShaderHelper.cs
@@ -101,7 +101,7 @@ namespace PlanBuild.Utils
         {
             if (gameObject.TryGetComponent(out WearNTear wearNTear) && wearNTear.m_oldMaterials != null)
             {
-                wearNTear.ResetHighlight();
+                Extensions.ResetHighlight(wearNTear);
             }
 
             foreach (Renderer renderer in GetRenderers(gameObject))
@@ -117,6 +117,11 @@ namespace PlanBuild.Utils
             }
         }
 
+        private static String AdjustMaterialName(String name)
+        {
+            return name.Split(' ')[0];
+        }
+
         private static void UpdateMaterials(ShaderState shaderState, Material[] sharedMaterials)
         {
             for (int j = 0; j < sharedMaterials.Length; j++)
@@ -126,9 +131,10 @@ namespace PlanBuild.Utils
                 {
                     continue;
                 }
-                if (!OriginalMaterialDict.ContainsKey(originalMaterial.name))
+                String adjustedMaterialName = AdjustMaterialName(originalMaterial.name);
+                if (!OriginalMaterialDict.ContainsKey(adjustedMaterialName))
                 {
-                    OriginalMaterialDict[originalMaterial.name] = originalMaterial;
+                    OriginalMaterialDict[adjustedMaterialName] = originalMaterial;
                 }
                 sharedMaterials[j] = GetMaterial(shaderState, originalMaterial);
             }
@@ -141,7 +147,7 @@ namespace PlanBuild.Utils
             switch (shaderState)
             {
                 case ShaderState.Skuld:
-                    return OriginalMaterialDict[originalMaterial.name];
+                    return OriginalMaterialDict[AdjustMaterialName(originalMaterial.name)];
 
                 case ShaderState.Supported:
                     if (!SupportedMaterialDict.TryGetValue(originalMaterial.name, out Material supportedMaterial))

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "PlanBuild",
   "description": "PlanBuild enables you to plan, copy and share your building creations in Valheim with ease. Includes terrain tools and immersion items.",
-  "version_number": "0.18.0",
+  "version_number": "0.18.1",
   "dependencies": [
     "denikson-BepInExPack_Valheim-5.4.2202",
     "ValheimModding-Jotunn-2.20.3",


### PR DESCRIPTION
fixes #98
fixes #103  

**Changes**
- Add method to properly reset highlighting caused within Extensions.cs
- Reset highlighting after deselection of a material
- Remove unnecessary break of enumeration during selection coroutine (properly select after equipping blueprint rune)
- Fix Skuld Crystal causing selection to appear although the blueprint rune is not selected
- Fix Skuld Crystal rendering wrong materials (e.g. transparent materials instead of solid ones) due to mismatch in `OriginalMaterialsDict` (caused by new material instances having different names)
- Bump project version to v0.18.1
- Update changelog

**Notes**
- Since the original code causes the creation of new material instances during the change of material color, [a hack is introduced here](https://github.com/sea212/PlanBuild/blob/09b6ffa18e8b1dd6dbbb4893f7129adbc20f65f7/PlanBuild/Utils/ShaderHelper.cs#L120-L123) to always keep the original material data cached and accessible within other modules. https://github.com/sirskunkalot/PlanBuild/issues/110 should be implemented to avoid having to do this and provide a more efficient implementation in general.

**Release-Builds**
[PlanBuild-0.18.1.0.zip](https://github.com/user-attachments/files/17806944/PlanBuild-0.18.1.0.zip)
[PlanBuild-0.18.1.0-nexus.zip](https://github.com/user-attachments/files/17806946/PlanBuild-0.18.1.0-nexus.zip)
[PlanBuild-0.18.1.0-tsio.zip](https://github.com/user-attachments/files/17806948/PlanBuild-0.18.1.0-tsio.zip)
