### PR TITLE
Update for Compatability with ComfyGizmo

### DIFF
--- a/PlanBuild/ModCompat/PatcherGizmo.cs
+++ b/PlanBuild/ModCompat/PatcherGizmo.cs
@@ -52,7 +52,13 @@ namespace PlanBuild.ModCompat
                         }
                     }
                 }
-                return _ComfyGizmoInstalled.Value && GizmosType is not null && GizmosHideMethod is not null && GizmosField is not null;
+
+                bool canPatchGizmo = GizmosType is not null && GizmosHideMethod is not null && GizmosField is not null;
+                if (_ComfyGizmoInstalled.Value && !canPatchGizmo)
+                {
+                    Jotunn.Logger.LogWarning("Found ComfyGizmo installed but cannot patch it!");
+                }
+                return _ComfyGizmoInstalled.Value && canPatchGizmo;
             }
         }
 

--- a/PlanBuild/ModCompat/PatcherGizmo.cs
+++ b/PlanBuild/ModCompat/PatcherGizmo.cs
@@ -1,29 +1,93 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
 using HarmonyLib;
+using BepInEx;
 using PlanBuild.Blueprints;
 using PlanBuild.Blueprints.Components;
 using PlanBuild.Plans;
 
 namespace PlanBuild.ModCompat
 {
-    internal class PatcherGizmo
+    internal static class PatcherGizmo
     {
-        [HarmonyPatch(typeof(ComfyGizmo.Patches.PlayerPatch), "UpdatePlacementPostfix")]
+        public const string GizmoGUID = "bruce.valheim.comfymods.gizmo";
+        private static bool? _ComfyGizmoInstalled = null;
+        private static BaseUnityPlugin ComfyGizmoPlugin;
+
+        private const string ComfyGizmoTargetType = "ComfyGizmo.Gizmos";
+        private static Type GizmosType;
+
+        private const string GizmosFieldName = "_gizmoInstances";
+        private static FieldInfo GizmosField;
+
+        private const string GizmosHideMethodName = "Hide";
+        private static MethodInfo GizmosHideMethod;
+
+        private static readonly List<object> EmptyList = new List<object>();
+
+        /// <summary>
+        ///     Get whether comfy gizmo is installed and the target fields/methods 
+        ///     can be accessed via reflection to apply the desired patches.
+        /// </summary>
+        public static bool ComfyGizmoInstalled
+        {
+            get
+            {
+                // Check for ComfyGizmo
+                _ComfyGizmoInstalled ??= BepInEx.Bootstrap.Chainloader.PluginInfos.ContainsKey(GizmoGUID);
+                if (_ComfyGizmoInstalled.Value && GizmosType is null)
+                {
+                    ComfyGizmoPlugin ??= BepInEx.Bootstrap.Chainloader.PluginInfos[GizmoGUID].Instance;
+                    Type[] types = AccessTools.GetTypesFromAssembly(ComfyGizmoPlugin.GetType().Assembly);
+                    foreach (Type type in types)
+                    {
+                        if (type.ToString() == ComfyGizmoTargetType)
+                        {
+                            GizmosType ??= type;
+                            GizmosHideMethod ??= AccessTools.Method(type, GizmosHideMethodName);
+                            GizmosField ??= AccessTools.Field(type, GizmosFieldName);
+                            break;
+                        }
+                    }
+                }
+                return _ComfyGizmoInstalled.Value && GizmosType is not null && GizmosHideMethod is not null && GizmosField is not null;
+            }
+        }
+
+        private static List<object> GetGizmoInstances()
+        {
+            if (!ComfyGizmoInstalled)
+            {
+                return EmptyList;
+            }
+            return (List<object>)GizmosField.GetValue(null);
+
+        }
+
+        [HarmonyPatch("ComfyGizmo.PlayerPatch", "UpdatePlacementPostfix")]
         [HarmonyPrefix]
         private static bool ComfyGizmo_UpdatePlacementPostfix_Prefix()
         {
-            if (!(Player.m_localPlayer && Player.m_localPlayer.m_buildPieces&&
-                  Player.m_localPlayer.m_placementGhost && ComfyGizmo.Gizmos._gizmoInstances.Count > 0))
+            if (!Player.m_localPlayer || Player.m_localPlayer.m_buildPieces || !Player.m_localPlayer.m_placementGhost)
             {
                 return true;
             }
-            
+
+            // cache this to avoid performing multiple casts to List<object>
+            var gizmoInstances = GetGizmoInstances();
+            if (gizmoInstances.Count <= 0)
+            {
+                return true;
+            }
+
             if (Player.m_localPlayer.m_placementGhost.TryGetComponent<ToolComponentBase>(out var tool) &&
                 tool.SuppressGizmo)
             {
-                foreach (var gizmoInstance in ComfyGizmo.Gizmos._gizmoInstances)
+                foreach (var gizmoInstance in gizmoInstances)
                 {
-                    gizmoInstance.Hide();
+                    GizmosHideMethod.Invoke(gizmoInstance, null);
                 }
                 return false;
             }
@@ -31,11 +95,10 @@ namespace PlanBuild.ModCompat
             if (Player.m_localPlayer.m_buildPieces.name.StartsWith(PlanHammerPrefab.PieceTableName, StringComparison.Ordinal) &&
                 Player.m_localPlayer.m_placementGhost.name.StartsWith(PlanHammerPrefab.PieceDeletePlansName, StringComparison.Ordinal))
             {
-                foreach (var gizmoInstance in ComfyGizmo.Gizmos._gizmoInstances)
+                foreach (var gizmoInstance in gizmoInstances)
                 {
-                    gizmoInstance.Hide();
+                    GizmosHideMethod.Invoke(gizmoInstance, null);
                 }
-                return false;
             }
 
             return true;

--- a/PlanBuild/Patches.cs
+++ b/PlanBuild/Patches.cs
@@ -9,7 +9,6 @@ namespace PlanBuild
         public const string BuildCameraGUID = "org.gittywithexcitement.plugins.valheim.buildCamera";
         public const string CraftFromContainersGUID = "aedenthorn.CraftFromContainers";
         public const string AzuCraftyBoxesGUID = "Azumatt.AzuCraftyBoxes";
-        public const string GizmoGUID = "bruce.valheim.comfymods.gizmo";
         public const string ValheimRaftGUID = "BepIn.Sarcen.ValheimRAFT";
         public const string ItemDrawersGUID = "mkz.itemdrawers";
 
@@ -37,7 +36,7 @@ namespace PlanBuild
                 Harmony.PatchAll(typeof(ModCompat.PatcherAzuCraftyBoxes));
             }
 
-            if (Chainloader.PluginInfos.ContainsKey(GizmoGUID))
+            if (ModCompat.PatcherGizmo.ComfyGizmoInstalled)
             {
                 Jotunn.Logger.LogInfo("Applying Gizmo patches");
                 Harmony.PatchAll(typeof(ModCompat.PatcherGizmo));

--- a/PlanBuild/PlanBuild.csproj
+++ b/PlanBuild/PlanBuild.csproj
@@ -60,11 +60,6 @@
       <HintPath>..\libraries\pub\AzuCraftyBoxes-publicized.dll</HintPath>
       <Private>False</Private>
     </Reference>
-    <Reference Include="ComfyGizmo">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\libraries\pub\ComfyGizmo.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
     <Reference Include="Jotunn, Version=2.19.2.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\JotunnLib.2.19.2\lib\net462\Jotunn.dll</HintPath>
     </Reference>

--- a/PlanBuild/PlanBuildPlugin.cs
+++ b/PlanBuild/PlanBuildPlugin.cs
@@ -12,6 +12,7 @@ using PlanBuild.Plans;
 using System.Reflection;
 using UnityEngine;
 using ShaderHelper = PlanBuild.Utils.ShaderHelper;
+using PlanBuild.ModCompat;
 
 namespace PlanBuild
 {
@@ -20,7 +21,7 @@ namespace PlanBuild
     [BepInDependency(Patches.BuildCameraGUID, BepInDependency.DependencyFlags.SoftDependency)]
     [BepInDependency(Patches.CraftFromContainersGUID, BepInDependency.DependencyFlags.SoftDependency)]
     [BepInDependency(Patches.AzuCraftyBoxesGUID, BepInDependency.DependencyFlags.SoftDependency)]
-    [BepInDependency(Patches.GizmoGUID, BepInDependency.DependencyFlags.SoftDependency)]
+    [BepInDependency(PatcherGizmo.GizmoGUID, BepInDependency.DependencyFlags.SoftDependency)]
     [BepInDependency(Patches.ValheimRaftGUID, BepInDependency.DependencyFlags.SoftDependency)]
     [BepInDependency(Patches.ItemDrawersGUID, BepInDependency.DependencyFlags.SoftDependency)]
     [NetworkCompatibility(CompatibilityLevel.ServerMustHaveMod, VersionStrictness.Minor)]


### PR DESCRIPTION
This modifies `PatcherGizmo` to access `ComfyGizmo` via reflection rather than a direct assembly reference. `PatcherGizmo` now only returns `True` for `IsComfyGizmoInstalled` if it can find the target fields and methods it needs to access inside the harmony patch. The namespaces for accessing `ComfyGizmo` have also been updated to resolve the current compatibility issue. 

Hopefully this approach, along with the warning that will be logged whenever `ComfyGizmo` is detected but cannot be patched, will make maintaining compatibility easier as the dll reference to `ComfyGizmo` won't need to be updated and errors won't be thrown if the namespaces in `ComfyGizmo` change. 
