### PR TITLE
fix(totem): use hitData to detect damage destruction instead of GetHealthPercentage

### DIFF
--- a/PlanBuild/Plans/PlanManager.cs
+++ b/PlanBuild/Plans/PlanManager.cs
@@ -219,9 +219,9 @@ namespace PlanBuild.Plans
         
         private static void WearNTear_Destroy(On.WearNTear.orig_Destroy orig, WearNTear wearNTear, HitData hitData, bool blockDrop)
         {
-            // Check if actually destoyed, not removed by middle clicking with Hammer
+            // Check if actually destroyed by damage (hitData non-null), not removed by middle clicking with Hammer
             if (wearNTear.m_nview && wearNTear.m_nview.IsOwner()
-                                  && wearNTear.GetHealthPercentage() <= 0f
+                                  && hitData != null
                                   && PlanDB.Instance.FindPlanByPrefabName(wearNTear.name, out PlanPiecePrefab planPrefab))
             {
                 foreach (PlanTotem planTotem in PlanTotem.m_allPlanTotems)


### PR DESCRIPTION
Fixes #127.                                                                                                                                                                                              
                                               
  The Bog Witch update refactored `WearNTear.Destroy` to accept `HitData` and `blockDrop` parameters. After this change, Valheim no longer writes `health = 0` to the ZDO before calling `Destroy`, so     
  `GetHealthPercentage() <= 0f` always reads the pre-damage value and returns `false` — meaning PlanTotems never detect piece destruction and no replacement plans are created.                            
                                                                                                                                                                                                           
  ## Fix                                                          

  Replace the health check with `hitData != null`:

  ```diff
  - && wearNTear.GetHealthPercentage() <= 0f
  + && hitData != null
  ```

  `hitData` is non-null for all damage-triggered destruction (weapons, mobs, structural collapse) and `null` for hammer removal, making it the correct signal for this distinction and restoring the
  original intended behaviour.