### PR TITLE
fix: compatibility with Valheim 1.0.7 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Version 0.18.5
+* Compatible with Valheim 1.0.7
+* Fixed crash on player spawn (camera snapping to world origin and infinite player spawn loop) caused by `Hoverable` gaining a new `GetHoverOffset` member and `PieceTable.m_availablePieces` changing shape in Valheim 1.0.7
+
 # Version 0.18.4
 * Fixed PlanTotem rebuilding plans for destroyed pieces (thx nickweedon)
 * Fixed the paint tool to calculate correct areas again

--- a/PlanBuild/Blueprints/Blueprint.cs
+++ b/PlanBuild/Blueprints/Blueprint.cs
@@ -702,7 +702,7 @@ namespace PlanBuild.Blueprints
                     additionalInfo += $"{armorStand.m_slots.Count}:";
                     foreach (var slot in armorStand.m_slots)
                     {
-                        additionalInfo += $"{slot.m_visualName}:{slot.m_visualVariant}:";
+                        additionalInfo += $"{slot.m_currentItemName}:{slot.m_visualVariant}:";
                     }
                 }
                 Door door = piece.GetComponent<Door>();

--- a/PlanBuild/Blueprints/BlueprintManager.cs
+++ b/PlanBuild/Blueprints/BlueprintManager.cs
@@ -265,11 +265,11 @@ namespace PlanBuild.Blueprints
                     {
                         List<Piece> reorder = new List<Piece>();
                         reorder.Add(BlueprintAssets.PlaceholderObject.GetComponent<Piece>());
-                        reorder.AddRange(self.m_availablePieces[(int)cat]
+                        reorder.AddRange(self.m_availablePiecesByCategory[(int)cat]
                             .OrderBy(x => x.m_name)
                             .Where(x => !x.name.Equals(BlueprintAssets.PiecePlaceholderName))
                             .ToList());
-                        self.m_availablePieces[(int)cat] = reorder;
+                        self.m_availablePiecesByCategory[(int)cat] = reorder;
                     }
                 }
             }

--- a/PlanBuild/Blueprints/Components/PlacementComponent.cs
+++ b/PlanBuild/Blueprints/Components/PlacementComponent.cs
@@ -221,7 +221,7 @@ namespace PlanBuild.Blueprints.Components
                 Piece newpiece = gameObject.GetComponent<Piece>();
                 if (newpiece)
                 {
-                    newpiece.SetCreator(player.GetPlayerID());
+                    newpiece.SetCreator(player.GetPlayerID(), Splatform.PlatformUserID.None);
 
                     if (placeDirect && cntEffects < maxEffects)
                     {
@@ -232,7 +232,7 @@ namespace PlanBuild.Blueprints.Components
 
                     if (placeDirect)
                     {
-                        Game.instance.GetPlayerProfile().m_playerStats.m_stats[PlayerStatType.Builds]++;
+                        Game.instance.GetPlayerProfile().IncrementStat(PlayerStatType.Builds, 1f, false);
                     }
                 }
                 CraftingStation craftingStation = gameObject.GetComponentInChildren<CraftingStation>();
@@ -291,7 +291,7 @@ namespace PlanBuild.Blueprints.Components
                         zNetView.m_zdo.Set("variant", variant);
                         zNetView.m_zdo.Set("quality", quality);
                         zNetView.m_zdo.Set("type", orientation);
-                        itemStand.SetVisualItem(item, variant, quality, orientation);
+                        itemStand.SetVisualItem(item.GetStableHashCode(), variant, quality, orientation);
                     }
                 }
                 ArmorStand armorStand = gameObject.GetComponent<ArmorStand>();
@@ -315,7 +315,7 @@ namespace PlanBuild.Blueprints.Components
                             var variant = int.Parse(fields[j * 2 + 3]);
                             zNetView.m_zdo.Set($"{j}_item", item);
                             zNetView.m_zdo.Set($"{j}_variant", variant);
-                            armorStand.SetVisualItem(j, item, variant);
+                            armorStand.SetVisualItem(j, item.GetStableHashCode(), variant);
                         }
                     }
                 }

--- a/PlanBuild/Blueprints/SelectionTools.cs
+++ b/PlanBuild/Blueprints/SelectionTools.cs
@@ -27,8 +27,8 @@ namespace PlanBuild.Blueprints
             Player.m_localPlayer.UpdateKnownRecipesList();
             Player.m_localPlayer.UpdateAvailablePiecesList();
             int cat = (int)PieceManager.Instance.GetPieceCategory(BlueprintAssets.CategoryClipboard);
-            List<Piece> reorder = Player.m_localPlayer.m_buildPieces.m_availablePieces[cat].OrderByDescending(x => x.name).ToList();
-            Player.m_localPlayer.m_buildPieces.m_availablePieces[cat] = reorder;
+            List<Piece> reorder = Player.m_localPlayer.m_buildPieces.m_availablePiecesByCategory[cat].OrderByDescending(x => x.name).ToList();
+            Player.m_localPlayer.m_buildPieces.m_availablePiecesByCategory[cat] = reorder;
             Player.m_localPlayer.m_buildPieces.m_selectedCategory = (Piece.PieceCategory)cat;
             Player.m_localPlayer.m_buildPieces.SetSelected(new Vector2Int(0, 0));
             Player.m_localPlayer.SetupPlacementGhost();

--- a/PlanBuild/Blueprints/TerrainModMarker.cs
+++ b/PlanBuild/Blueprints/TerrainModMarker.cs
@@ -187,5 +187,10 @@ namespace PlanBuild.Blueprints
             return false;
         }
 
+        public float GetHoverOffset()
+        {
+            return 0f;
+        }
+
     }
 }

--- a/PlanBuild/Blueprints/TerrainTools.cs
+++ b/PlanBuild/Blueprints/TerrainTools.cs
@@ -45,7 +45,7 @@ namespace PlanBuild.Blueprints
             compiler.m_lastOpPoint = Vector3.zero;
             compiler.m_lastOpRadius = 0f;
             compiler.Save();
-            compiler.m_hmap.Poke(false);
+            compiler.m_hmap.Poke(0, false);
         }
 
         private static Indices FilterByBlockCheck(Indices indices, BlockCheck blockCheck)
@@ -62,7 +62,7 @@ namespace PlanBuild.Blueprints
             List<Heightmap> heightMaps = new List<Heightmap>();
             Heightmap.FindHeightmap(position, radius + 1f, heightMaps);
             var pos = position;
-            return heightMaps.Where(hmap => ZNetScene.InActiveArea(ZoneSystem.GetZone(hmap.transform.position), pos))
+            return heightMaps.Where(hmap => ZNetScene.InActiveArea(pos, ZoneSystem.GetZone(hmap.transform.position)))
                 .Select(hmap => hmap.GetAndCreateTerrainCompiler());
         }
 
@@ -77,7 +77,7 @@ namespace PlanBuild.Blueprints
             var size = maxDimension * dimensionMultiplier / 2f;
             Heightmap.FindHeightmap(position, size + 1f, heightMaps);
             var pos = position;
-            return heightMaps.Where(hmap => ZNetScene.InActiveArea(ZoneSystem.GetZone(hmap.transform.position), pos))
+            return heightMaps.Where(hmap => ZNetScene.InActiveArea(pos, ZoneSystem.GetZone(hmap.transform.position)))
                 .Select(hmap => hmap.GetAndCreateTerrainCompiler());
         }
 

--- a/PlanBuild/Blueprints/WorldBlueprintRune.cs
+++ b/PlanBuild/Blueprints/WorldBlueprintRune.cs
@@ -53,5 +53,10 @@ namespace PlanBuild.Blueprints
         {
             return false;
         }
+
+        public float GetHoverOffset()
+        {
+            return 0f;
+        }
     }
 }

--- a/PlanBuild/PlanBuild.csproj
+++ b/PlanBuild/PlanBuild.csproj
@@ -203,7 +203,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="JotunnLib">
-      <Version>2.28.0</Version>
+      <Version>2.30.0</Version>
     </PackageReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/PlanBuild/PlanBuildPlugin.cs
+++ b/PlanBuild/PlanBuildPlugin.cs
@@ -15,7 +15,7 @@ using UnityEngine;
 namespace PlanBuild
 {
     [BepInPlugin(PluginGUID, PluginName, PluginVersion)]
-    [BepInDependency(Jotunn.Main.ModGuid, "2.24.2")]
+    [BepInDependency(Jotunn.Main.ModGuid, "2.30.0")]
     [BepInDependency(Patches.BuildCameraGUID, BepInDependency.DependencyFlags.SoftDependency)]
     [BepInDependency(Patches.CraftFromContainersGUID, BepInDependency.DependencyFlags.SoftDependency)]
     [BepInDependency(Patches.AzuCraftyBoxesGUID, BepInDependency.DependencyFlags.SoftDependency)]
@@ -27,7 +27,7 @@ namespace PlanBuild
     {
         public const string PluginGUID = "marcopogo.PlanBuild";
         public const string PluginName = "PlanBuild";
-        public const string PluginVersion = "0.18.4";
+        public const string PluginVersion = "0.18.5";
 
         public static PlanBuildPlugin Instance;
 

--- a/PlanBuild/Plans/OdinLevel.cs
+++ b/PlanBuild/Plans/OdinLevel.cs
@@ -23,5 +23,10 @@ namespace PlanBuild.Plans
         {
             return false;
         }
+
+        public float GetHoverOffset()
+        {
+            return 0f;
+        }
     }
 }

--- a/PlanBuild/Plans/PlanHammerPrefab.cs
+++ b/PlanBuild/Plans/PlanHammerPrefab.cs
@@ -97,14 +97,14 @@ namespace PlanBuild.Plans
                 PieceManager.Instance.AddPieceTable(planPieceTable);
 
                 // Add empty lists up to the max categories count
-                for (int i = planPieceTable.PieceTable.m_availablePieces.Count; i < (int)Piece.PieceCategory.All; i++)
+                for (int i = planPieceTable.PieceTable.m_availablePiecesByCategory.Count; i < (int)Piece.PieceCategory.All; i++)
                 {
-                    planPieceTable.PieceTable.m_availablePieces.Add(new List<Piece>());
+                    planPieceTable.PieceTable.m_availablePiecesByCategory.Add(new List<Piece>());
                 }
 
                 // Resize selectedPiece array
                 Array.Resize(ref planPieceTable.PieceTable.m_selectedPiece,
-                    planPieceTable.PieceTable.m_availablePieces.Count);
+                    planPieceTable.PieceTable.m_availablePiecesByCategory.Count);
 
                 // Set table on the hammer
                 PlanHammerItem.ItemDrop.m_itemData.m_shared.m_buildPieces = planPieceTable.PieceTable;

--- a/PlanBuild/Plans/PlanPiece.cs
+++ b/PlanBuild/Plans/PlanPiece.cs
@@ -257,6 +257,11 @@ namespace PlanBuild.Plans
             return Localization.instance.Localize("[<color=yellow>$KEY_Use</color>] $plan_piece_hover_build");
         }
 
+        public float GetHoverOffset()
+        {
+            return 0f;
+        }
+
         private void SetupPieceInfo(Piece piece)
         {
             Player localPlayer = Player.m_localPlayer;
@@ -657,7 +662,7 @@ namespace PlanBuild.Plans
                 }
 
                 // Count up player builds
-                Game.instance.GetPlayerProfile().m_playerStats.m_stats[PlayerStatType.Builds]++;
+                Game.instance.GetPlayerProfile().IncrementStat(PlayerStatType.Builds, 1f, false);
             }
             WearNTear wearntear = actualPiece.GetComponent<WearNTear>();
             if (wearntear)
@@ -674,7 +679,7 @@ namespace PlanBuild.Plans
             {
                 itemdrop.MakePiece(true);
             }
-            actualPiece.GetComponent<Piece>().SetCreator(creatorID);
+            actualPiece.GetComponent<Piece>().SetCreator(creatorID, Splatform.PlatformUserID.None);
             return actualPiece;
         }
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,10 +1,10 @@
 {
   "name": "PlanBuild",
   "description": "PlanBuild enables you to plan, copy and share your building creations in Valheim with ease. Includes terrain tools and immersion items.",
-  "version_number": "0.18.4",
+  "version_number": "0.18.5",
   "dependencies": [
-    "denikson-BepInExPack_Valheim-5.4.2333",
-    "ValheimModding-Jotunn-2.28.0",
+    "denikson-BepInExPack_Valheim-5.4.2350",
+    "ValheimModding-Jotunn-2.30.0",
     "ValheimModding-HookGenPatcher-0.0.4"
   ],
   "website_url": "https://github.com/sirskunkalot/PlanBuild"


### PR DESCRIPTION
Fixes a crash-on-spawn (camera snapping to world origin, infinite Player(Clone) spawn loop) caused by binary incompatibilities between this build and Valheim 1.0.7:

- Hoverable gained a new GetHoverOffset() member; PlanPiece, WorldBlueprintRune, TerrainModMarker, and OdinLevel didn't implement it, so the CLR failed to load their types (TypeLoadException: VTable setup failed) the moment anything touched them. Since one of those touches happens inside Player.Awake(), every player spawn attempt crashed and Game.UpdateRespawn retried forever.
- PieceTable.m_availablePieces changed from List<List<Piece>> to a flat HashSet<Piece>; the old per-category list now lives in a new field, m_availablePiecesByCategory. Updated the three call sites that indexed it by category.
- Heightmap.Poke gained a leading int parameter.
- ZNetScene.InActiveArea(Vector3, Vector2s) argument order changed.
- ArmorStand.ArmorStandSlot.m_visualName was renamed to m_currentItemName.
- Piece.SetCreator now requires a Splatform.PlatformUserID argument.
- PlayerProfile stat tracking moved from m_playerStats.m_stats[...] to IncrementStat(PlayerStatType, float, bool).
- ItemStand.SetVisualItem and ArmorStand.SetVisualItem now take an int item-name hash instead of a string.

Bumped JotunnLib 2.28.0 -> 2.30.0 and BepInExPack_Valheim 5.4.2333 -> 5.4.2350 to match, and version 0.18.4 -> 0.18.5.